### PR TITLE
Added wrapper to fetch method

### DIFF
--- a/_examples/node-ts/webapp/client.gen.ts
+++ b/_examples/node-ts/webapp/client.gen.ts
@@ -66,7 +66,7 @@ export class ExampleService implements ExampleService {
 
   constructor(hostname: string, fetch: Fetch) {
     this.hostname = hostname
-    this.fetch = fetch
+    this.fetch = (input: RequestInfo, init?: RequestInit) => fetch(input, init)
   }
 
   private url(name: string): string {

--- a/_examples/node-ts/webapp/index.ts
+++ b/_examples/node-ts/webapp/index.ts
@@ -1,9 +1,6 @@
 import { ExampleService } from './client.gen'
 
-const exampleService = new ExampleService(
-	'http://localhost:3000',
-	(input, init) => fetch(input, init)
-)
+const exampleService = new ExampleService('http://localhost:3000', fetch)
 
 document.addEventListener('DOMContentLoaded', () => {
 	const pingButton = document.getElementById('js-ping-btn')

--- a/client.go.tmpl
+++ b/client.go.tmpl
@@ -15,7 +15,7 @@ export class {{.Name}} implements {{.Name}} {
 
   constructor(hostname: string, fetch: Fetch) {
     this.hostname = hostname
-    this.fetch = fetch
+    this.fetch = (input: RequestInfo, init?: RequestInit) => fetch(input, init)
   }
 
   private url(name: string): string {


### PR DESCRIPTION
This is a copy of https://github.com/webrpc/webrpc/pull/103#issue-1226318031


This allows directly pass the fetch method without binding it to the window first

https://stackoverflow.com/questions/69876859/why-does-bind-fix-failed-to-execute-fetch-on-window-illegal-invocation-err