### PR TITLE
Fixes https://github.com/webrpc/webrpc/issues/167

### DIFF
--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -23,8 +23,8 @@ export enum {{$enumName}} {
 export interface {{.Name}} {
   {{- range .Fields}}
   {{- $isExportable := true -}}
-  {{- range $meta := .Meta -}} 
-      {{- if eq (get $meta "json") "-" -}}
+  {{- range $meta := .Meta -}}
+      {{- if eq (printf "%v" (get $meta "json")) "-" -}}
         {{- $isExportable = false}}
       {{- end -}}
   {{- end }}


### PR DESCRIPTION
Fixes

```
types.go.tmpl:27:13: executing "types" at <eq (get $meta "json") "-">: error calling eq: incompatible types for comparison
```

```
$ cd _examples/hello-webrpc-ts/Makefile && make generate
make[1]: Entering directory '/home/runner/work/webrpc/webrpc/_examples/hello-webrpc-ts'
webrpc-gen -schema=hello-api.ridl -target=golang -pkg=main -server -out=./server/hello_api.gen.go
=======================================
|      webrpc generated summary       |
=======================================
 webrpc-gen version : v0.8.x-dev
 target             : github.com/webrpc/gen-golang
 target cache       : /tmp/webrpc-cache/2568534563-gen-golang
 target cache age   : 5m54s
 schema file        : hello-api.ridl
 output file        : ./server/hello_api.gen.go
webrpc-gen -schema=hello-api.ridl -target=typescript -client -out=./webapp/src/client.gen.ts

template: types.go.tmpl:27:13: executing "types" at <eq (get $meta "json") "-">: error calling eq: incompatible types for comparison
```