### PR TITLE
Backport AbortSignal feature from cohere.ai

### DIFF
--- a/_examples/node-ts/server/server.gen.ts
+++ b/_examples/node-ts/server/server.gen.ts
@@ -37,8 +37,8 @@ export interface Page {
 }
 
 export interface ExampleService {
-  ping(headers?: object): Promise<PingReturn>
-  getUser(args: GetUserArgs, headers?: object): Promise<GetUserReturn>
+  ping(headers?: object, signal?: AbortSignal): Promise<PingReturn>
+  getUser(args: GetUserArgs, headers?: object, signal?: AbortSignal): Promise<GetUserReturn>
 }
 
 export interface PingArgs {

--- a/_examples/node-ts/server/tsconfig.json
+++ b/_examples/node-ts/server/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
-      "es2016"
+      "es2016",
+      "DOM"
     ] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/_examples/node-ts/webapp/client.gen.ts
+++ b/_examples/node-ts/webapp/client.gen.ts
@@ -279,4 +279,4 @@ const webrpcErrorByCode: { [code: number]: any } = {
   [-6]: WebrpcServerPanicError,
 }
 
-export type Fetch = (input: RequestInfo, init?: RequestInit, abortSignal?: AbortSignal) => Promise<Response>
+export type Fetch = (input: RequestInfo, init?: RequestInit) => Promise<Response>

--- a/_examples/node-ts/webapp/client.gen.ts
+++ b/_examples/node-ts/webapp/client.gen.ts
@@ -37,8 +37,8 @@ export interface Page {
 }
 
 export interface ExampleService {
-  ping(headers?: object): Promise<PingReturn>
-  getUser(args: GetUserArgs, headers?: object): Promise<GetUserReturn>
+  ping(headers?: object, signal?: AbortSignal): Promise<PingReturn>
+  getUser(args: GetUserArgs, headers?: object, signal?: AbortSignal): Promise<GetUserReturn>
 }
 
 export interface PingArgs {
@@ -74,11 +74,11 @@ export class ExampleService implements ExampleService {
     return this.hostname + this.path + name
   }
   
-  ping = (headers?: object): Promise<PingReturn> => {
+  ping = (headers?: object, signal?: AbortSignal): Promise<PingReturn> => {
     return this.fetch(
       this.url('Ping'),
-      createHTTPRequest({}, headers)
-    ).then((res) => {
+      createHTTPRequest({}, headers, signal)
+      ).then((res) => {
       return buildResponse(res).then(_data => {
         return {}
       })
@@ -87,11 +87,10 @@ export class ExampleService implements ExampleService {
     })
   }
   
-  getUser = (args: GetUserArgs, headers?: object): Promise<GetUserReturn> => {
+  getUser = (args: GetUserArgs, headers?: object, signal?: AbortSignal): Promise<GetUserReturn> => {
     return this.fetch(
       this.url('GetUser'),
-      createHTTPRequest(args, headers)
-    ).then((res) => {
+      createHTTPRequest(args, headers, signal)).then((res) => {
       return buildResponse(res).then(_data => {
         return {
           code: <number>(_data.code),
@@ -105,11 +104,12 @@ export class ExampleService implements ExampleService {
   
 }
 
-  const createHTTPRequest = (body: object = {}, headers: object = {}): object => {
+  const createHTTPRequest = (body: object = {}, headers: object = {}, signal: AbortSignal | null = null): object => {
   return {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body || {})
+    body: JSON.stringify(body || {}),
+    signal
   }
 }
 
@@ -279,4 +279,4 @@ const webrpcErrorByCode: { [code: number]: any } = {
   [-6]: WebrpcServerPanicError,
 }
 
-export type Fetch = (input: RequestInfo, init?: RequestInit) => Promise<Response>
+export type Fetch = (input: RequestInfo, init?: RequestInit, abortSignal?: AbortSignal) => Promise<Response>

--- a/client.go.tmpl
+++ b/client.go.tmpl
@@ -26,10 +26,10 @@ export class {{.Name}} implements {{.Name}} {
     return this.fetch(
       this.url('{{.Name}}'),
       {{- if .Inputs | len}}
-      createHTTPRequest(args, headers)
+      createHTTPRequest(args, headers, signal)
       {{- else}}
-      createHTTPRequest({}, headers)
-      {{- end}}
+      createHTTPRequest({}, headers, signal)
+      {{end -}}
     ).then((res) => {
       return buildResponse(res).then(_data => {
         return {

--- a/clientHelpers.go.tmpl
+++ b/clientHelpers.go.tmpl
@@ -2,11 +2,12 @@
 {{- $webrpcErrors := .WebrpcErrors -}}
 {{- $schemaErrors := .SchemaErrors -}}
 
-const createHTTPRequest = (body: object = {}, headers: object = {}): object => {
+const createHTTPRequest = (body: object = {}, headers: object = {}, signal: AbortSignal | null = null): object => {
   return {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body || {})
+    body: JSON.stringify(body || {}),
+    signal
   }
 }
 
@@ -109,5 +110,5 @@ const webrpcErrorByCode: { [code: number]: any } = {
 {{- end }}
 }
 
-export type Fetch = (input: RequestInfo, init?: RequestInit) => Promise<Response>
+export type Fetch = (input: RequestInfo, init?: RequestInit, abortSignal?: AbortSignal) => Promise<Response>
 {{end}}

--- a/clientHelpers.go.tmpl
+++ b/clientHelpers.go.tmpl
@@ -110,5 +110,5 @@ const webrpcErrorByCode: { [code: number]: any } = {
 {{- end }}
 }
 
-export type Fetch = (input: RequestInfo, init?: RequestInit, abortSignal?: AbortSignal) => Promise<Response>
+export type Fetch = (input: RequestInfo, init?: RequestInit) => Promise<Response>
 {{end}}

--- a/methodInputs.go.tmpl
+++ b/methodInputs.go.tmpl
@@ -3,5 +3,5 @@
 {{- $method := .Method -}}
 {{- $typeMap := .TypeMap -}}
 
-{{if gt (len $method.Inputs) 0}}args: {{$method.Name}}Args, {{end}}headers?: object
+{{if gt (len $method.Inputs) 0}}args: {{$method.Name}}Args, {{end}}headers?: object, signal?: AbortSignal
 {{- end -}}


### PR DESCRIPTION
Backport AbortSignal feature from cohere.ai fork

Credits:
- @kipply
- @udameli
- @wujessica
- @1vn
- @robertkozi

https://github.com/cohere-ai/webrpc/pull/1
https://github.com/cohere-ai/webrpc/pull/3
https://github.com/cohere-ai/webrpc/pull/2

---

AbortSignal docs
https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal

---

Example
```
  const controller = new AbortController();
  const signal = controller.signal
  setTimeout(() => controller.abort(), 5000)
  const { user } = await rpc.GetUser({ userId }, null, signal);
```