### PR TITLE
Add Status to client definitions

### DIFF
--- a/clientHelpers.go.tmpl
+++ b/clientHelpers.go.tmpl
@@ -76,7 +76,7 @@ export class {{$error.Name}}Error extends WebrpcError {
     name: string = '{{$error.Name}}',
     code: number = {{$error.Code}},
     message: string = `{{$error.Message}}`,
-    status: number = 0,
+    status: number = {{$error.Status}},
     cause?: string
   ) {
     super(name, code, message, status, cause)


### PR DESCRIPTION
Right now clients don't have info about the status. We could add it just for sake of completion.


<img width="805" alt="image" src="https://github.com/user-attachments/assets/d5829b4e-ee8a-4955-8078-3d0d48c3a334" />
