### PR TITLE
Remove dangling reference to eliminated "message" variable in clientSSE

### DIFF
--- a/clientSSE.go.tmpl
+++ b/clientSSE.go.tmpl
@@ -56,7 +56,7 @@ const sseResponse = async (
                 onError(
                     WebrpcClientAbortedError.new({
                         message: "AbortError",
-                        cause: `AbortError: ${message}`,
+                        cause: `AbortError: ${error instanceof Error ? error.message : String(error)}`,
                     }),
                     () => {
                         throw new Error("Abort signal cannot be used to reconnect");


### PR DESCRIPTION
https://github.com/webrpc/gen-typescript/commit/8afe13b1ed7bf078e81e7dd3dfb7231da5a94779 eliminated a variable "message" that still had one dangling reference. This PR replicates the changes made elsewhere to fix it.