### PR TITLE
Close SSE empty line type loophole

### DIFF
--- a/clientSSE.go.tmpl
+++ b/clientSSE.go.tmpl
@@ -76,7 +76,7 @@ const sseResponse = async (
         let lines = buffer.split("\n");
         for (let i = 0; i < lines.length - 1; i++) {
             const line = lines[i];
-            if (line?.length === 0) {
+            if (!line || line.length === 0) {
                 continue;
             }
             let data: any;


### PR DESCRIPTION
`line?.length === 0` will be falsy even if `line` is `undefined`. If the `tsc` option `noUncheckedIndexedAccess` is enabled, array dereferences always run the risk of being `undefined`. Thus, the call to `JSON.parse` will generate errors. Changing the emptiness test to `!line || line.length === 0` closes off this possibility and makes the `JSON.parse` call happy.