### PR TITLE
ci: pin webrpc-gen install to released v0.37.4 tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           go-version: "1.23"
 
-      - name: Install webrpc-gen (development)
-        run: git clone --single-branch https://github.com/webrpc/webrpc.git --branch feat/type-alias && cd webrpc && make install
+      - name: Install webrpc-gen
+        run: git clone --single-branch https://github.com/webrpc/webrpc.git --branch v0.37.4 && cd webrpc && make install
 
       - name: Regenerate examples
         run: cd _examples && make generate


### PR DESCRIPTION
CI installed `webrpc-gen` from the `feat/type-alias` dev branch of webrpc, which has since been merged and deleted upstream, so the clone step failed (exit 128) on every PR before any checks ran. This pins the install to the latest release tag `v0.37.4`, which includes the type-alias support. Verified locally that cloning the tag builds cleanly and that `make generate` + `make diff` produce a clean diff against the committed generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)