### PR TITLE
docs(readme): document -schemaHash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Change any of the following values by passing `-option="Value"` CLI flag to `web
 | `-client`          | generate client code                    | `false`       | v0.0.1  |
 | `-server`          | generate server code                    | `false`       | v0.0.1  |
 | `-webrpcHeader`    | send Webrpc header in all HTTP requests | `true`        | v0.15.0 |
+| `-schemaHash=false` | don't emit schema hash + version consts | `true`        | v0.28.0 |
 
 **Note:** Generated code requires ES2022+ runtime environment.
 


### PR DESCRIPTION
The `-schemaHash` opt-out (default-on) was missing from the README options table, so it was undiscoverable unless you read the template. This adds the missing row. (`-help` already lists it — that output is generated from the opts dict — so only the hand-maintained table needed updating.)

---

Docs-only; no template or generated-code change. `-schemaHash=false` omits the schema hash + version consts from the generated output, which removes the per-edit hash churn that causes merge conflicts.

Part of a sweep documenting this flag across the generators (gen-golang webrpc/gen-golang#122 already up).
